### PR TITLE
fixed locale to english

### DIFF
--- a/polyglot/detect/base.py
+++ b/polyglot/detect/base.py
@@ -28,6 +28,7 @@ class Language(object):
     self.locale = Locale(code)
     self.confidence = float(confidence)
     self.read_bytes = int(bytesize)
+    self.locale.setDefault(self.locale.getEnglish())
 
   @property
   def name(self):


### PR DESCRIPTION
My default locale is `Chinese` and When I call the `Detector class`  to detect language, it just raise `UnicodeEncodeError`. I figure out the problem by adding ` self.locale.setDefault(self.locale.getEnglish())`  in the `__init__` function .